### PR TITLE
Fix for Issue 15 - Refresh incorrectly triggers when doing a continuous long touch

### DIFF
--- a/libraryproject/src/eu/erikw/PullToRefreshListView.java
+++ b/libraryproject/src/eu/erikw/PullToRefreshListView.java
@@ -294,7 +294,7 @@ public class PullToRefreshListView extends ListView{
                 break;
 
             case MotionEvent.ACTION_MOVE:
-                if(previousY != -1){
+                if(previousY != -1 && getFirstVisiblePosition() == 0){
                     float y = event.getY();
                     float diff = y - previousY;
                     if(diff > 0) diff /= PULL_RESISTANCE;


### PR DESCRIPTION
Fixed by checking the first visible item during move motion events.
